### PR TITLE
Target netstandard2.0

### DIFF
--- a/src/Cyjs.NET/Cyjs.NET.fsproj
+++ b/src/Cyjs.NET/Cyjs.NET.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0; net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
@@ -31,7 +31,7 @@
     <None Include="img\icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DynamicObj" Version="0.0.1" />
+    <PackageReference Include="DynamicObj" Version="0.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
fixes #3

Target `netstandard2.0` instead of `netstandard2.1` for wider compatability.

As `DynamicObj 0.0.1` only targets `netstandard2.1`, the reference was updated to `DynamicObj 0.0.3` 